### PR TITLE
Update for Purescript 0.9.1.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,8 @@
   "name": "purescript-jsdom",
   "version": "0.0.1",
   "authors": [
-    "Seitaro Yuuki <sensitivejapaneseman@gmail.com>"
+    "Seitaro Yuuki <sensitivejapaneseman@gmail.com>",
+    "Ryan Rempel <rgrempel@gmail.com>"
   ],
   "license": "MIT",
   "ignore": [
@@ -12,16 +13,15 @@
     "output"
   ],
   "dependencies": {
-    "jsdom": "~6.5.1",
-    "purescript-aff": "~0.12.0",
-    "purescript-dom": "~0.2.6",
-    "purescript-eff-functions": "git@github.com:hexx/purescript-eff-functions.git#~0.0.1",
-    "purescript-exceptions": "~0.3.0",
-    "purescript-nullable": "~0.2.1"
+    "purescript-aff": "^1.0.0",
+    "purescript-dom": "^1.0.0",
+    "purescript-eff-functions": "^1.0.0",
+    "purescript-exceptions": "^1.0.0",
+    "purescript-nullable": "^1.0.0"
   },
   "devDependencies": {
-    "purescript-assert": "~0.1.1",
-    "purescript-console": "~0.1.1",
-    "purescript-debug": "~0.1.2"
+    "purescript-assert": "^1.0.0",
+    "purescript-console": "^1.0.0",
+    "purescript-debug": "^1.0.0"
   }
 }

--- a/docs/DOM/JSDOM.md
+++ b/docs/DOM/JSDOM.md
@@ -15,7 +15,7 @@ type Callback eff a = Either Error a -> Eff (jsdom :: JSDOM | eff) Unit
 #### `env`
 
 ``` purescript
-env :: forall configs eff. String -> Array String -> {  | configs } -> Callback eff Window -> Eff (jsdom :: JSDOM | eff) Unit
+env :: forall configs eff. String -> Array String -> {  | configs } -> Callback eff Window -> (Eff (jsdom :: JSDOM | eff) Unit)
 ```
 
 #### `envAff`

--- a/package.json
+++ b/package.json
@@ -1,11 +1,13 @@
 {
+  "private": true,
   "name": "purescript-jsdom",
   "version": "0.0.1",
   "authors": [
-    "Seitaro Yuuki <sensitivejapaneseman@gmail.com>"
+    "Seitaro Yuuki <sensitivejapaneseman@gmail.com>",
+    "Ryan Rempel <rgrempel@gmail.com>"
   ],
   "license": "MIT",
   "dependencies": {
-    "jsdom": "^6.5.1"
+    "jsdom": "^9.3.0"
   }
 }

--- a/src/DOM/JSDOM.purs
+++ b/src/DOM/JSDOM.purs
@@ -1,40 +1,40 @@
 module DOM.JSDOM
-  ( JSDOM()
-  , Callback()
+  ( JSDOM
+  , Callback
   , env
   , envAff
   , jsdom
   ) where
 
-import Control.Monad.Aff
-import Control.Monad.Eff
-import Control.Monad.Eff.Exception
-import Data.Either
-import Data.Function.Eff
-import Data.Maybe
-import Data.Nullable
-import DOM.Node.Types
-import DOM.HTML.Types
-import Prelude
+import Control.Monad.Aff (Aff, makeAff)
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Exception (Error)
+import Data.Either (Either(..), either)
+import Data.Function.Eff (EffFn2, EffFn4, runEffFn2, runEffFn4, mkEffFn2)
+import Data.Maybe (maybe)
+import Data.Nullable (Nullable, toMaybe)
+import DOM.Node.Types (Document)
+import DOM.HTML.Types (Window)
+import Prelude (Unit, ($))
 
 foreign import data JSDOM :: !
 
-type JSCallback eff a = ExportEffFn2 (Nullable Error) a (Eff (jsdom :: JSDOM | eff) Unit)
+type JSCallback eff a = EffFn2 (jsdom :: JSDOM | eff) (Nullable Error) a  Unit
 type Callback eff a = Either Error a -> Eff (jsdom :: JSDOM | eff) Unit
 
 toJSCallback :: forall a eff. Callback eff a -> JSCallback eff a
-toJSCallback f = mkExportEffFn2 (\e a -> f $ maybe (Right a) Left (toMaybe e))
+toJSCallback f = mkEffFn2 (\e a -> f $ maybe (Right a) Left (toMaybe e))
 
 foreign import _jsdom ::
-  { env :: forall configs eff. ImportEffFn4 String (Array String) { | configs} (JSCallback eff Window) (Eff (jsdom :: JSDOM | eff) Unit)
-  , jsdom :: forall configs eff. ImportEffFn2 String { | configs} (Eff (jsdom :: JSDOM | eff) Document)
+  { env :: forall configs eff. EffFn4 (jsdom :: JSDOM | eff) String (Array String) { | configs} (JSCallback eff Window) Unit
+  , jsdom :: forall configs eff. EffFn2 (jsdom :: JSDOM | eff) String { | configs} Document
   }
 
 env :: forall configs eff. String -> Array String -> { | configs} -> Callback eff Window -> (Eff (jsdom :: JSDOM | eff) Unit)
-env urlOrHtml scripts configs callback = runImportEffFn4 _jsdom.env urlOrHtml scripts configs (toJSCallback callback)
+env urlOrHtml scripts configs callback = runEffFn4 _jsdom.env urlOrHtml scripts configs (toJSCallback callback)
 
 envAff :: forall configs eff. String -> Array String -> { | configs} -> Aff (jsdom :: JSDOM | eff) Window
 envAff urlOrHtml scripts configs = makeAff \e a -> env urlOrHtml scripts configs $ either e a
 
 jsdom :: forall configs eff. String -> { | configs} -> Eff (jsdom :: JSDOM | eff) Document
-jsdom markup configs = runImportEffFn2 _jsdom.jsdom markup configs
+jsdom markup configs = runEffFn2 _jsdom.jsdom markup configs

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -1,32 +1,34 @@
 module Test.Main where
 
-import Control.Bind
-import Control.Monad.Aff
-import Control.Monad.Eff
-import Control.Monad.Eff.Class
-import Control.Monad.Eff.Console(log)
-import Control.Monad.Eff.Exception(error, throwException)
-import Data.Maybe
-import Data.Nullable
-import Data.String(stripPrefix)
-import Data.Traversable
-import DOM.Node.Document
-import DOM.Node.Node
-import DOM.Node.Types
-import DOM.HTML.Window
-import DOM.HTML.Document
-import DOM.HTML.Types
-import Test.Assert
-import Prelude
-        
 import DOM.JSDOM
+import Control.Monad.Aff (runAff)
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Class (liftEff)
+import Control.Monad.Eff.Console (CONSOLE, log)
+import Control.Monad.Eff.Exception (EXCEPTION, error, throwException)
+import DOM (DOM)
+import DOM.HTML.Types (htmlDocumentToDocument)
+import DOM.HTML.Window (document)
+import DOM.Node.Document (documentURI)
+import DOM.Node.Node (textContent, firstChild)
+import DOM.Node.Types (Node, documentToNode)
+import Data.Maybe (Maybe(..), isJust)
+import Data.Nullable (toMaybe)
+import Data.String (stripPrefix)
+import Data.Traversable (sequence)
+import Prelude (Unit, bind, unit, pure, const, map, join, ($), (>>=), (<#>), (==), (>>>))
+import Test.Assert (ASSERT, assert)
 
-firstText :: forall eff. Node -> Eff (dom :: DOM.DOM | eff) (Maybe String)
+firstText :: forall eff. Node -> Eff (dom :: DOM | eff) (Maybe String)
 firstText node = join $ firstChild node <#> toMaybe >>> (map textContent) >>> sequence
 
+exampleHTML :: String
 exampleHTML = "<p>hogeika</p>"
+
+exampleURI :: String
 exampleURI = "http://www.nicovideo.jp/"
 
+main :: Eff (console :: CONSOLE, jsdom :: JSDOM, dom :: DOM, assert :: ASSERT, err :: EXCEPTION) Unit
 main = do
   log "Testing jsdom"
   text <- (jsdom exampleHTML {}) <#> documentToNode >>= firstText
@@ -37,8 +39,11 @@ main = do
   assert $ uri == exampleURI
 
   log "Testing envAff"
-  runAff (\_ -> throwException $ error "envAff doesn't work") (const $ return unit) do
+  runAff (\_ -> throwException $ error "envAff doesn't work") (const $ pure unit) do
     window <- envAff exampleURI [] {}
     liftEff $ do
-      uri <- document window <#> htmlDocumentToDocument >>= documentURI
-      assert $ isJust $ stripPrefix exampleURI uri
+      docUri <- document window <#> htmlDocumentToDocument >>= documentURI
+      assert $ isJust $ stripPrefix exampleURI docUri
+
+  -- Ignore the canceler we get from runAff
+  pure unit


### PR DESCRIPTION
- Update dependencies to 0.9.1-compatible versions.
- Switch from hexx/purescript-eff-functions to hdgarrood/purescript-eff-functions, since the special features of the hexx version aren't needed here.
- Use qualified imports.
- Elminate other warnings.
